### PR TITLE
Add on drag end event handler

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -25,7 +25,7 @@
     "react/jsx-quotes": [2, "double", "avoid-escape"],
     "react/jsx-uses-react": 2,
     "react/jsx-uses-vars": 2,
-    "react/no-did-mount-set-state": 2,
+    "react/no-did-mount-set-state": 1,
     "react/no-did-update-set-state": 2,
     "react/no-unknown-property": 2,
     "react/react-in-jsx-scope": 2,

--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ var Volume = React.createClass({
 		};
 	}
 
+  // Will be called once and the end of dragging the slider
+  handleDragEnd: function(value) {
+    // Do something with value here
+  }
+
+  // Will be called on every change while draggin the slider
 	handleChange: function(value) {
 		this.setState({
 			value: value,
@@ -37,7 +43,8 @@ var Volume = React.createClass({
 			<Slider
         value={value}
         orientation="vertical"
-        onChange={this.handleChange} />
+        onChange={this.handleChange} 
+        onDragEnd={this.handleDragEnd} />
 		);
 	}
 });
@@ -59,6 +66,12 @@ export default Volume extends Component {
     };
   }
 
+  // Will be called once and the end of dragging the slider
+  handleDragEnd(value) {
+    // Do something with value here
+  }
+
+  // Will be called on every change while draggin the slider
   handleChange(value) {
     this.setState({
       value: value
@@ -70,7 +83,8 @@ export default Volume extends Component {
       <Slider
         value={value}
         orientation="vertical"
-        onChange={this.handleChange} />
+        onChange={this.handleChange} 
+        onDragEnd={this.handleDragEnd} />
     );
   }
 }
@@ -92,7 +106,8 @@ var Slider = require('react-rangeslider');
 	step={String or Number}
 	orientation={String}
   value={Number}
-  onChange={Function} />
+  onChange={Function} 
+  onDragEnd={Function} />
 ```
 
 ### Props
@@ -104,7 +119,8 @@ Prop   	 			 |  Default      |  Description
 `step` 				 |  1          	 |  step in which increments/decrements have to be made
 `orientation`  |  horizontal   |  orientation of the slider
 `value`  			 |  -            |  current value of the slider
-`onChange`  	 |  -            |  function the slider takes, current value of the slider as the first parameter
+`onChange`  	 |  -            |  function the slider takes, current value of the slider as the first parameter. Will be called on every value change during the drag.
+`onDragEnd`    |  -            |  function the slider takes, current value of the slider as the first parameter. Will be called once on the end of the drag.
 
 
 ## Issues

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -14,6 +14,10 @@ class Demo extends Component {
 		};
 	}
 
+	handleDragEnd = (value) => {
+		console.log(`Finished dragging. Value is ${value}`)
+	}
+
 	handleChangeHor = (value) => {
 		this.setState({
 			hor: value
@@ -55,7 +59,8 @@ class Demo extends Component {
 						min={0}
 						max={100}
 						value={hor}
-						onChange={this.handleChangeHor} />
+						onChange={this.handleChangeHor}
+						onDragEnd={this.handleDragEnd} />
 					<div className="value">Value: {hor}</div>
 					<hr/>
 

--- a/src/index.js
+++ b/src/index.js
@@ -34,6 +34,7 @@ class Slider extends Component {
 		value: PropTypes.number,
 		orientation: PropTypes.string,
 		onChange: PropTypes.func,
+  	onDragEnd: PropTypes.func,
 		className: PropTypes.string,
 	}
 
@@ -83,9 +84,16 @@ class Slider extends Component {
   	onChange && onChange(value);
   }
 
-  handleDragEnd = () => {
+  handleDragEnd = (e) => {
   	document.removeEventListener('mousemove', this.handleDrag);
   	document.removeEventListener('mouseup', this.handleDragEnd);
+
+    const { onDragEnd } = this.props;
+    if (!onDragEnd) {
+      return;
+    } 
+    const value = this.position(e);
+    onDragEnd(value);
   }
 
   handleNoop = (e) => {


### PR DESCRIPTION
With a slider it is useful to be able to handle the drag end event separately from the onChange event (the on change is called many times on every drag and sometimes you just want the end result).
So I added a hander for onDragEnd